### PR TITLE
update readme re: jinja highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 Adds syntax highlighting to [SaltStack](http://saltstack.com) files in Atom.
 
+For Jinja highlighting, install [atom-jinja2](https://atom.io/packages/atom-jinja2).
+
 Contributions are greatly appreciated. Please fork this repository and open a
 pull request to add snippets, make grammar tweaks, etc.


### PR DESCRIPTION
`language-yaml` is included with Atom by default, but Jinja syntax highlighting is not. For that you need the `atom-jinja2` package.

This PR updates the README to reflect that.
