### PR TITLE
Set tab length to two

### DIFF
--- a/settings/language-salt.json
+++ b/settings/language-salt.json
@@ -4,7 +4,8 @@
       "commentStart": "# ",
       "foldEndPattern": "^\\s*$|^\\s*\\}|^\\s*\\]|^\\s*\\)",
       "increaseIndentPattern": "^\\s*.*(:|-) ?(&\\w+)?(\\{[^}\"']*|\\([^)\"']*)?$",
-      "decreaseIndentPattern": "^\\s+\\}$"
+      "decreaseIndentPattern": "^\\s+\\}$",
+      "tabLength": 2
     }
   }
 }


### PR DESCRIPTION
Thoughts on this? Set tab length to two since that is the standard for state files in salt.
